### PR TITLE
PER-8720: FusionAuth Index Page

### DIFF
--- a/theme/helpers.ftl
+++ b/theme/helpers.ftl
@@ -1062,13 +1062,18 @@
   [/#if]
 [/#macro]
 
-[#macro permHeader]
+[#macro permHeader showAdminLock=false]
   <header>
     <div class="perm-banner">
       <div class="banner-content">
         <a href="${PERM_DOMAIN}">
           <img class="banner-logo" src="${PERM_DOMAIN}/app/assets/img/logo/sideways_logo.png">
         </a>
+        [#if showAdminLock]
+          <a href="/admin/" title="Administrative Login">
+            <i class="fa fa-lock" style="font-size: 18px; color: #fff; opacity: 0.5;"></i>
+          </a>
+        [/#if]
       </div>
     </div>
   </header>
@@ -1089,6 +1094,7 @@
   <meta name="theme-color" content="#ffffff" />
   <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;600;700&display=swap" rel="stylesheet" />
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
+  <link rel="stylesheet" href="/css/font-awesome-4.7.0.min.css"/>
   [#if !(bypassTheme!false)]
   <style tyle="text/css">
   ${theme.stylesheet()?no_esc}

--- a/theme/index.ftl
+++ b/theme/index.ftl
@@ -1,0 +1,23 @@
+[#ftl/]
+[#-- @ftlvariable name="tenant" type="io.fusionauth.domain.Tenant" --]
+[#-- @ftlvariable name="tenantId" type="java.util.UUID" --]
+[#import "_helpers.ftl" as helpers/]
+
+<!doctype html>
+<html>
+  [@helpers.permHeadTag title="Permanent.org - FusionAuth"/]
+  <body class="permanent">
+    [@helpers.permHeader showAdminLock=true/]
+
+    <main style="text-align: center;">
+      <h1>Welcome!</h1>
+      <p>The Permanent web application can be found on <a href="https://permanent.org/app">Permanent.org</a></p>
+      [#-- Maybe put a link to account self service here? --]
+    </main>
+
+    [#-- Using an HTML comment so this is visible in the rendered HTML. We don't want to freak anyone out. --]
+    <!-- Feel free to remove this, it is just a stupid easter egg. Enjoy. -->
+    <!--   "Escape is impossible when you're caught in the net" https://www.imdb.com/title/tt0113957/  -->
+    <div style="position:fixed; left:0; bottom: 0; margin-bottom: 7px; margin-left: 10px;"><a style="color: #fff;" href="https://the-praetorians.net" title="Escape is impossible when you're caught in the net.">π</a></div>
+  </body>
+</html>

--- a/theme/index.ftl
+++ b/theme/index.ftl
@@ -15,9 +15,11 @@
       [#-- Maybe put a link to account self service here? --]
     </main>
 
-    [#-- Using an HTML comment so this is visible in the rendered HTML. We don't want to freak anyone out. --]
-    <!-- Feel free to remove this, it is just a stupid easter egg. Enjoy. -->
-    <!--   "Escape is impossible when you're caught in the net" https://www.imdb.com/title/tt0113957/  -->
-    <div style="position:fixed; left:0; bottom: 0; margin-bottom: 7px; margin-left: 10px;"><a style="color: #fff;" href="https://the-praetorians.net" title="Escape is impossible when you're caught in the net.">π</a></div>
+    [#if tenantId == "0d4161cf-c520-e5fa-9250-e23ba0e3e6a3" ]
+      [#-- Using an HTML comment so this is visible in the rendered HTML. We don't want to freak anyone out. --]
+      <!-- Feel free to remove this, it is just a stupid easter egg. Enjoy. -->
+      <!--   "Escape is impossible when you're caught in the net" https://www.imdb.com/title/tt0113957/  -->
+      <div style="position:fixed; left:0; bottom: 0; margin-bottom: 7px; margin-left: 10px;"><a style="color: #eee;" href="https://the-praetorians.net" title="Escape is impossible when you're caught in the net.">π</a></div>
+    [/#if]
   </body>
 </html>

--- a/theme/stylesheet.css
+++ b/theme/stylesheet.css
@@ -21,6 +21,7 @@ html, body {
   display: flex;
   height: 100%;
   align-items: center;
+  justify-content: space-between;
 }
 
 .perm-banner .banner-logo {


### PR DESCRIPTION
<del>why did I make this a separate branch off of main when I have the other branch's code still on the dev instance. why would I do this</del>

This is the re-themed version of the FusionAuth index page for Permanent's instance. The page includes a link to the main web-app as well as the lock icon link to the admin section.

The original FusionAuth index template features a rather notable inclusion in its footer element, which I have mostly kept preserved in this restyling. So I'd like to open up what is probably the most silly and pointless PR discussion ever: <span title="Personally I would never put an easter egg in the Permanent app myself, but also I think easter eggs are precious and I don't want to just destroy one, you know? ...... wait... does this hover text count as an easter egg????">**Should we keep in FusionAuth's default easter egg or remove it?** I've left it in for this initial commit because I don't want to single-handedly make a "no fun allowed" judgement call here, but I feel like the easter egg is even *more* confusing in the context of our page and audience in particular. BUT... normal users should never even reach this page anyway without URL hacking.</span>

Resolves PER-8720. Interestingly enough, the ticket also mentions the "change password complete" page, which is already done. I assume that's because of the weirdness of some of the FusionAuth theming tickets. I think?

You can test this by just going to the Permanent FusionAuth Dev Instance's index page!