### PR TITLE
Update OAuth two factor action to be compatible with FusionAuth 1.37.0

### DIFF
--- a/theme/oauth-twofactor.ftl
+++ b/theme/oauth-twofactor.ftl
@@ -32,7 +32,7 @@
       <h1 class="form-title">${theme.message('two-factor-challenge')}</h1>
 
       [#setting url_escaping_charset='UTF-8']
-      <form id="2fa-form" action="two-factor" method="POST" class="full">
+      <form id="2fa-form" action="/oauth2/two-factor" method="POST" class="full">
         [@helpers.prInput type="text" fieldName="code" autocapitalize="none" autocomplete="one-time-code" autocorrect="off" autofocus=true placeholder=theme.message('code')/]
 
         [@helpers.oauthHiddenFields/]


### PR DESCRIPTION
Change based on the issue noted under 1.37.0 in the [FusionAuth release notes](https://fusionauth.io/docs/v1/tech/release-notes).

Note that the Oauth authorize and change password actions, which we also use, are affected by this issue as well but we appear to already be using compatible paths in these cases.