### PR TITLE
PER-9156: Link to reset password via Permanent

### DIFF
--- a/email/forgot-password-html.ftl
+++ b/email/forgot-password-html.ftl
@@ -1,7 +1,7 @@
 [#setting url_escaping_charset="UTF-8"]
 [#-- The optional 'state' map provided on the Forgot Password API call is exposed in the template as 'state' --]
 [#assign domain = "{ENTER DOMAIN HERE}" /]
-[#assign url = "https://${domain}/password/change/${changePasswordId}?tenantId=${user.tenantId}" /]
+[#assign url = "https://${domain}/app/fa-reset/${changePasswordId}?tenantId=${user.tenantId}" /]
 [#list state!{} as key, value][#if key != "tenantId" && value??][#assign url = url + "&" + key?url + "=" + value?url/][/#if][/#list]
 <!doctype html>
 <html lang="en">

--- a/email/forgot-password-txt.ftl
+++ b/email/forgot-password-txt.ftl
@@ -1,7 +1,7 @@
 [#setting url_escaping_charset="UTF-8"]
 [#-- The optional 'state' map provided on the Forgot Password API call is exposed in the template as 'state' --]
 [#assign domain = "{ENTER DOMAIN HERE}" /]
-[#assign url = "https://${domain}/password/change/${changePasswordId}?tenantId=${user.tenantId}" /]
+[#assign url = "https://${domain}/app/fa-reset/${changePasswordId}?tenantId=${user.tenantId}" /]
 [#list state!{} as key, value][#if key != "tenantId" && value??][#assign url = url + "&" + key?url + "=" + value?url/][/#if][/#list]
 
 You are receiving this email because you have requested to change your password on Permanent.org. Follow the link below to reset your password:


### PR DESCRIPTION
As created in https://github.com/PermanentOrg/web-app/pull/192, point to Permanent from the "forgot password" email instead of directly to FusionAuth.